### PR TITLE
remove sensor param from script tag

### DIFF
--- a/djangocms_googlemap/templates/cms/plugins/googlemap.html
+++ b/djangocms_googlemap/templates/cms/plugins/googlemap.html
@@ -66,7 +66,7 @@ function initializeMap{{ object.pk}}() {
 {% endaddtoblock %}
 
 {% addtoblock "js" %}
-<script type="text/javascript" src="https://maps-api-ssl.google.com/maps/api/js?v=3&amp;sensor=true&amp;callback=initializeMap{{ object.pk }}"></script>
+<script type="text/javascript" src="https://maps-api-ssl.google.com/maps/api/js?v=3&amp;callback=initializeMap{{ object.pk }}"></script>
 {% endaddtoblock %}
 
 


### PR DESCRIPTION
The sensor parameter is deprecated by the google maps api and causes a warning in the js console.
https://developers.google.com/maps/documentation/javascript/error-messages#sensor-not-required