### PR TITLE
Implement the ability to configure google API key

### DIFF
--- a/djangocms_googlemap/cms_plugins.py
+++ b/djangocms_googlemap/cms_plugins.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.utils.translation import ugettext_lazy as _
 
 from cms.plugin_base import CMSPluginBase
@@ -31,6 +32,7 @@ class GoogleMapPlugin(CMSPluginBase):
         context.update({
             'object': instance,
             'placeholder': placeholder,
+            'google_api_key': getattr(settings, 'DJANGOCMS_GOOGLEMAP_API_KEY')
         })
         return context
 

--- a/djangocms_googlemap/templates/djangocms_googlemap/googlemap.html
+++ b/djangocms_googlemap/templates/djangocms_googlemap/googlemap.html
@@ -44,5 +44,5 @@
     {% endif %}
 </div>
 
-{% addtoblock "js" %}<script src="//maps-api-ssl.google.com/maps/api/js?v=3"></script>{% endaddtoblock %}
+{% addtoblock "js" %}<script src="https://maps.googleapis.com/maps/api/js?key={{ google_api_key }}"></script>{% endaddtoblock %}
 {% addtoblock "js" %}<script src="{% static 'djangocms_googlemap/js/djangocms.googlemaps.js' %}"></script>{% endaddtoblock %}


### PR DESCRIPTION
Since Google has changed the access rules to their Google Maps API,
this plugin require a way to provide the API Key to use
such a service.

Set your API Key into the `DJANGOCMS_GOOGLEMAP_API_KEY` variable
in your Django settings module to make it work.
