### PR TITLE
Fix missing references provoking broken PyPI desc

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,9 +7,9 @@ A Google Maps plugin for django CMS.
 Installation
 ------------
 
-This plugin requires `django CMS` 3.0 or higher to be properly installed.
+This plugin requires `django CMS`_ 3.0 or higher to be properly installed.
 
-* In your projects `virtualenv`_, run ``pip install djangocms-googlemap``.
+* In your project's `virtualenv`_, run ``pip install djangocms-googlemap``.
 * Add ``'djangocms_googlemap'`` to your ``INSTALLED_APPS`` setting.
 * If using Django 1.6 and South < 1.0.2 add ``'djangocms_googlemap': 'djangocms_googlemap.migrations_django',``
   to ``SOUTH_MIGRATION_MODULES`` (or define ``SOUTH_MIGRATION_MODULES`` if it
@@ -20,7 +20,9 @@ This plugin requires `django CMS` 3.0 or higher to be properly installed.
 Translations
 ------------
 
-If you want to help translate the plugin please do it on transifex:
+If you want to help translate the plugin please do it on `transifex`_.
 
-https://www.transifex.com/projects/p/django-cms/resource/djangocms-googlemap/
 
+.. _django CMS: https://github.com/divio/django-cms
+.. _virtualenv: https://virtualenv.pypa.io/en/stable/
+.. _Transifex: https://www.transifex.com/divio/djangocms-googlemap/

--- a/djangocms_googlemap/__init__.py
+++ b/djangocms_googlemap/__init__.py
@@ -1,3 +1,5 @@
-# -*- coding: utf-8 -*-
+"""
+Google Maps plugin for django CMS
+"""
 
 __version__ = '0.5.2rc1'

--- a/setup.py
+++ b/setup.py
@@ -16,8 +16,13 @@ CLASSIFIERS = [
     'Topic :: Communications',
     'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
     'Topic :: Internet :: WWW/HTTP :: Dynamic Content :: Message Boards',
+    'Programming Language :: Python :: 2',
     'Programming Language :: Python :: 2.6',
     'Programming Language :: Python :: 2.7',
+    'Programming Language :: Python :: 3',
+    'Programming Language :: Python :: 3.3',
+    'Programming Language :: Python :: 3.4',
+    'Programming Language :: Python :: 3.5',
 ]
 
 setup(
@@ -32,7 +37,7 @@ setup(
         'djangocms_googlemap.migrations',
         'djangocms_googlemap.south_migrations'
     ],
-    license='LICENSE.txt',
+    license='BSD License',
     platforms=['OS Independent'],
     classifiers=CLASSIFIERS,
     long_description=open('README.rst').read(),


### PR DESCRIPTION
On [PyPI](https://pypi.python.org/pypi/djangocms-googlemap) the package description is broken, i.e. not converted from reStructuredText to HTML correctly, most probably due to invalid syntax in the README, which provokes the reST -> HTML conversion to fail.

This PR
- Fixes missing references provoking broken PyPI description
- Moves more package descriptors to the package `__init__.py` (from `setup.py`)
- Fixes the incorrect specification of the license (Note: to refer to the `LICENSE.txt` file we should use a badge on top of the README)