### PR TITLE
Release version 1.0.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,7 +3,7 @@ Changelog
 =========
 
 
-1.0.0 (unreleased)
+1.0.0 (2016-11-14)
 ==================
 
 * Backwards incompatible changes

--- a/djangocms_googlemap/__init__.py
+++ b/djangocms_googlemap/__init__.py
@@ -1,2 +1,2 @@
 # -*- coding: utf-8 -*-
-__version__ = '1.0.0rc1'
+__version__ = '1.0.0'


### PR DESCRIPTION
* Backwards incompatible changes
    * Deprecated template ``templates/cms/plugins/googlemap.html``
    * Moved template from ``templates/djangocms_googlemap/googlemap.html`` to
      ``templates/djangocms_googlemap/default/map.html``
    * Added setting ``DJANGOCMS_GOOGLEMAP_API_KEY``
    * Added setting ``DJANGOCMS_GOOGMEMAP_TEMPLATES``
    * Removed Django < 1.8 support
    * Removed ``alt`` attribute and migrated data to Filer
    * Migrated data to separated nested plugins ``Marker`` and ``Route``
* Cleaned up file structure
* Updated ``README.txt``
* Updated translations