### PR TITLE
0005 migration fix

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,12 @@ Changelog
 =========
 
 
+1.0.2 (unreleased)
+==================
+* Fixed an issue where 0005 migration mismatches lat/lng values when creating
+  the new nested structure from older upgrades
+
+
 1.0.1 (2016-11-22)
 ==================
 * Prevent changes to ``DJANGOCMS_GOOGLEMAP_XXX`` settings from requiring new

--- a/djangocms_googlemap/migrations/0005_create_nested_plugins.py
+++ b/djangocms_googlemap/migrations/0005_create_nested_plugins.py
@@ -30,8 +30,8 @@ def create_marker_and_route(apps, schema_editor):
                 target=target,
                 # custom fields
                 address=address,
-                lat=gmap.lng,
-                lng=gmap.lat,
+                lat=gmap.lat,
+                lng=gmap.lng,
                 info_content=gmap.content,
             )
 


### PR DESCRIPTION
Fixed an issue where 0005 migration mismatches lat/lng values when creating
  the new nested structure from older upgrades