### PR TITLE
Release version 1.0.2

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,7 +3,7 @@ Changelog
 =========
 
 
-1.0.2 (unreleased)
+1.0.2 (2017-01-10)
 ==================
 * Fixed an issue where 0005 migration mismatches lat/lng values when creating
   the new nested structure from older upgrades

--- a/djangocms_googlemap/__init__.py
+++ b/djangocms_googlemap/__init__.py
@@ -1,2 +1,2 @@
 # -*- coding: utf-8 -*-
-__version__ = '1.0.1'
+__version__ = '1.0.2'


### PR DESCRIPTION
* Fixed an issue where 0005 migration mismatches lat/lng values when creating
  the new nested structure from older upgrades
* Updated translations