### PR TITLE
initial Django 2.0 support

### DIFF
--- a/djangocms_googlemap/migrations/0001_initial.py
+++ b/djangocms_googlemap/migrations/0001_initial.py
@@ -14,7 +14,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='GoogleMap',
             fields=[
-                ('cmsplugin_ptr', models.OneToOneField(serialize=False, parent_link=True, auto_created=True, to='cms.CMSPlugin', primary_key=True)),
+                ('cmsplugin_ptr', models.OneToOneField(serialize=False, parent_link=True, auto_created=True, to='cms.CMSPlugin', primary_key=True, on_delete=models.CASCADE)),
                 ('title', models.CharField(verbose_name='map title', blank=True, null=True, max_length=100)),
                 ('address', models.CharField(verbose_name='address', max_length=150)),
                 ('zipcode', models.CharField(verbose_name='zip code', max_length=30)),

--- a/djangocms_googlemap/migrations/0002_auto_20160622_1031.py
+++ b/djangocms_googlemap/migrations/0002_auto_20160622_1031.py
@@ -19,7 +19,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='googlemap',
             name='cmsplugin_ptr',
-            field=models.OneToOneField(parent_link=True, related_name='djangocms_googlemap_googlemap', auto_created=True, primary_key=True, serialize=False, to='cms.CMSPlugin'),
+            field=models.OneToOneField(parent_link=True, related_name='djangocms_googlemap_googlemap', auto_created=True, primary_key=True, serialize=False, to='cms.CMSPlugin', on_delete=models.CASCADE),
         ),
         migrations.AlterField(
             model_name='googlemap',

--- a/djangocms_googlemap/migrations/0004_adapted_fields.py
+++ b/djangocms_googlemap/migrations/0004_adapted_fields.py
@@ -40,7 +40,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='googlemap',
             name='cmsplugin_ptr',
-            field=models.OneToOneField(parent_link=True, related_name='djangocms_googlemap_googlemap', primary_key=True, serialize=False, to='cms.CMSPlugin'),
+            field=models.OneToOneField(parent_link=True, related_name='djangocms_googlemap_googlemap', primary_key=True, serialize=False, to='cms.CMSPlugin', on_delete=models.CASCADE),
         ),
         migrations.AlterField(
             model_name='googlemap',
@@ -150,7 +150,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='GoogleMapMarker',
             fields=[
-                ('cmsplugin_ptr', models.OneToOneField(parent_link=True, related_name='djangocms_googlemap_googlemapmarker', auto_created=True, primary_key=True, serialize=False, to='cms.CMSPlugin')),
+                ('cmsplugin_ptr', models.OneToOneField(parent_link=True, related_name='djangocms_googlemap_googlemapmarker', auto_created=True, primary_key=True, serialize=False, to='cms.CMSPlugin', on_delete=models.CASCADE)),
                 ('title', models.CharField(max_length=255, verbose_name='Title', blank=True)),
                 ('address', models.CharField(max_length=255, verbose_name='Full address', blank=True, help_text='Note: Latitude and longitude can be used to fine-tune the location.')),
                 ('lat', models.DecimalField(decimal_places=6, max_digits=10, blank=True, help_text='Geographical latitude in degrees (e.g. "46.947973").', null=True, verbose_name='Latitude (lat)')),
@@ -166,7 +166,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='GoogleMapRoute',
             fields=[
-                ('cmsplugin_ptr', models.OneToOneField(parent_link=True, related_name='djangocms_googlemap_googlemaproute', auto_created=True, primary_key=True, serialize=False, to='cms.CMSPlugin')),
+                ('cmsplugin_ptr', models.OneToOneField(parent_link=True, related_name='djangocms_googlemap_googlemaproute', auto_created=True, primary_key=True, serialize=False, to='cms.CMSPlugin', on_delete=models.CASCADE)),
                 ('title', models.CharField(max_length=255, verbose_name='Title', blank=True)),
                 ('origin', models.CharField(max_length=255, verbose_name='Starting address', blank=True, help_text='Will be determined by user\'s location (if possible) if left blank.')),
                 ('destination', models.CharField(max_length=255, verbose_name='Destination address')),

--- a/djangocms_googlemap/models.py
+++ b/djangocms_googlemap/models.py
@@ -160,6 +160,7 @@ class GoogleMap(CMSPlugin):
         CMSPlugin,
         related_name='%(app_label)s_%(class)s',
         parent_link=True,
+        on_delete=models.CASCADE,
     )
 
     def __str__(self):


### PR DESCRIPTION
Squashing some incompatibilities between Django 1.11 and 2.0.

django-cms is not Django 2.0 ready yet, but I'm trying to get various plugins and dependencies compatible to make it easier for the whole ecosystem to work on 2.0.x eventually.