### PR TITLE
Add support for new Django versions 1.11/2.0/2.1 and drop for 1.8/1.9/1.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,18 +4,15 @@ sudo: false
 
 env:
   - TOX_ENV=flake8
-  - TOX_ENV=py27-latest
-  - TOX_ENV=py34-latest
-  # Django 1.8
-  - TOX_ENV=py27-dj18-cms34
-  - TOX_ENV=py27-dj18-cms33
-  - TOX_ENV=py34-dj18-cms34
-  - TOX_ENV=py34-dj18-cms33
-  # Django 1.9
-  - TOX_ENV=py27-dj19-cms34
-  - TOX_ENV=py27-dj19-cms33
-  - TOX_ENV=py34-dj19-cms34
-  - TOX_ENV=py34-dj19-cms33
+  # Django 1.11
+  - TOX_ENV=py27-dj111-cms35
+  - TOX_ENV=py35-dj111-cms35
+  # Django 2.0
+  - TOX_ENV=py35-dj20-cms35
+  - TOX_ENV=py35-dj20-cms40
+  # Django 2.1
+  - TOX_ENV=py35-dj21-cms35
+  - TOX_ENV=py35-dj21-cms40
 
 install:
   - pip install tox coverage

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,11 +2,16 @@
 Changelog
 =========
 
-1.1.2 (unreleased)
+1.2.0 (unreleased)
 ==================
 
 * Fixed an issue with map not always setting correct zoom level
 * Removed admin url data attribute from the map marker if cms isn't in edit mode
+* Added support for Django 1.11, 2.0 and 2.1
+* Removed support for Django 1.8, 1.9, 1.10
+* Adapted testing infrastructure (tox/travis) to incorporate
+  django CMS 3.5 and 4.0
+
 
 1.1.1 (2017-06-16)
 ==================

--- a/README.rst
+++ b/README.rst
@@ -33,8 +33,8 @@ Documentation
 See ``REQUIREMENTS`` in the `setup.py <https://github.com/divio/djangocms-googlemap/blob/master/setup.py>`_
 file for additional dependencies:
 
-* Python 2.7, 3.3 or higher
-* Django 1.8 or higher
+* Python 2.7, 3.4 or higher
+* Django 1.11 or higher
 
 
 Installation

--- a/aldryn_config.py
+++ b/aldryn_config.py
@@ -12,7 +12,8 @@ class Form(forms.BaseForm):
         required=False,
     )
     api_key = forms.CharField(
-        'Google Maps API Key: Warning! This field is deprecated. Please leave it blank and set an environment variable called DJANGOCMS_GOOGLEMAP_API_KEY instead.'
+        'Google Maps API Key: Warning! This field is deprecated. '
+        'Please leave it blank and set an environment variable called DJANGOCMS_GOOGLEMAP_API_KEY instead.'
         'https://developers.google.com/maps/documentation/javascript/get-api-key',
         required=False,
     )

--- a/djangocms_googlemap/cms_plugins.py
+++ b/djangocms_googlemap/cms_plugins.py
@@ -1,12 +1,11 @@
 # -*- coding: utf-8 -*-
-from django.utils.translation import ugettext_lazy as _
 from django.conf import settings
+from django.utils.translation import ugettext_lazy as _
 
 from cms.plugin_base import CMSPluginBase
 from cms.plugin_pool import plugin_pool
 
 from . import models
-
 
 GOOGLEMAP_API_KEY = getattr(
     settings,

--- a/djangocms_googlemap/migrations/0001_initial.py
+++ b/djangocms_googlemap/migrations/0001_initial.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from django.db import models, migrations
+import django.db.models.deletion
+from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
@@ -14,7 +15,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='GoogleMap',
             fields=[
-                ('cmsplugin_ptr', models.OneToOneField(serialize=False, parent_link=True, auto_created=True, to='cms.CMSPlugin', primary_key=True)),
+                ('cmsplugin_ptr', models.OneToOneField(serialize=False, parent_link=True, auto_created=True, to='cms.CMSPlugin', primary_key=True, on_delete=django.db.models.deletion.CASCADE)),
                 ('title', models.CharField(verbose_name='map title', blank=True, null=True, max_length=100)),
                 ('address', models.CharField(verbose_name='address', max_length=150)),
                 ('zipcode', models.CharField(verbose_name='zip code', max_length=30)),

--- a/djangocms_googlemap/migrations/0002_auto_20160622_1031.py
+++ b/djangocms_googlemap/migrations/0002_auto_20160622_1031.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
+import django.db.models.deletion
 from django.db import migrations, models
 
 
@@ -19,7 +20,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='googlemap',
             name='cmsplugin_ptr',
-            field=models.OneToOneField(parent_link=True, related_name='djangocms_googlemap_googlemap', auto_created=True, primary_key=True, serialize=False, to='cms.CMSPlugin'),
+            field=models.OneToOneField(parent_link=True, related_name='djangocms_googlemap_googlemap', auto_created=True, primary_key=True, serialize=False, to='cms.CMSPlugin', on_delete=django.db.models.deletion.CASCADE),
         ),
         migrations.AlterField(
             model_name='googlemap',

--- a/djangocms_googlemap/migrations/0004_adapted_fields.py
+++ b/djangocms_googlemap/migrations/0004_adapted_fields.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
+import django.db.models.deletion
 from django.db import migrations, models
+
 from djangocms_googlemap.models import get_templates
 
 
@@ -40,7 +42,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='googlemap',
             name='cmsplugin_ptr',
-            field=models.OneToOneField(parent_link=True, related_name='djangocms_googlemap_googlemap', primary_key=True, serialize=False, to='cms.CMSPlugin'),
+            field=models.OneToOneField(parent_link=True, related_name='djangocms_googlemap_googlemap', primary_key=True, serialize=False, to='cms.CMSPlugin', on_delete=django.db.models.deletion.CASCADE),
         ),
         migrations.AlterField(
             model_name='googlemap',
@@ -150,7 +152,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='GoogleMapMarker',
             fields=[
-                ('cmsplugin_ptr', models.OneToOneField(parent_link=True, related_name='djangocms_googlemap_googlemapmarker', auto_created=True, primary_key=True, serialize=False, to='cms.CMSPlugin')),
+                ('cmsplugin_ptr', models.OneToOneField(parent_link=True, related_name='djangocms_googlemap_googlemapmarker', auto_created=True, primary_key=True, serialize=False, to='cms.CMSPlugin', on_delete=django.db.models.deletion.CASCADE)),
                 ('title', models.CharField(max_length=255, verbose_name='Title', blank=True)),
                 ('address', models.CharField(max_length=255, verbose_name='Full address', blank=True, help_text='Note: Latitude and longitude can be used to fine-tune the location.')),
                 ('lat', models.DecimalField(decimal_places=6, max_digits=10, blank=True, help_text='Geographical latitude in degrees (e.g. "46.947973").', null=True, verbose_name='Latitude (lat)')),
@@ -166,7 +168,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='GoogleMapRoute',
             fields=[
-                ('cmsplugin_ptr', models.OneToOneField(parent_link=True, related_name='djangocms_googlemap_googlemaproute', auto_created=True, primary_key=True, serialize=False, to='cms.CMSPlugin')),
+                ('cmsplugin_ptr', models.OneToOneField(parent_link=True, related_name='djangocms_googlemap_googlemaproute', auto_created=True, primary_key=True, serialize=False, to='cms.CMSPlugin', on_delete=django.db.models.deletion.CASCADE)),
                 ('title', models.CharField(max_length=255, verbose_name='Title', blank=True)),
                 ('origin', models.CharField(max_length=255, verbose_name='Starting address', blank=True, help_text='Will be determined by user\'s location (if possible) if left blank.')),
                 ('destination', models.CharField(max_length=255, verbose_name='Destination address')),

--- a/djangocms_googlemap/models.py
+++ b/djangocms_googlemap/models.py
@@ -5,25 +5,24 @@ from the google maps api.
 """
 from __future__ import unicode_literals
 
-import re
 import json
+import re
 
-from django.db import models
 from django.conf import settings
 from django.core.exceptions import ValidationError
+from django.db import models
 from django.utils.encoding import python_2_unicode_compatible
-from django.utils.translation import ugettext, ugettext_lazy as _
+from django.utils.translation import ugettext_lazy as _
 
 from cms.models import CMSPlugin
 
 from filer.fields.image import FilerImageField
 
-
 MAP_TYPES = ['ROADMAP', 'SATELLITE', 'HYBRID', 'TERRAIN']
 MAP_TYPE_CHOICES = [(map_type, map_type) for map_type in MAP_TYPES]
 TRAVEL_MODES = ['DRIVING', 'BICYCLING', 'TRANSIT', 'WALKING']
 TRAVEL_MODE_CHOICES = [(travel_mode, travel_mode) for travel_mode in TRAVEL_MODES]
-ZOOM_LEVEL_CHOICES = [(c, str(c)) for c in range(22)] # from 0 to 21
+ZOOM_LEVEL_CHOICES = [(c, str(c)) for c in range(22)]  # from 0 to 21
 
 CSS_WIDTH_RE = re.compile(r'^\d+(?:px|%)$')
 CSS_HEIGHT_RE = re.compile(r'^\d+px$')
@@ -74,7 +73,7 @@ class GoogleMap(CMSPlugin):
         verbose_name=_('Map styling'),
         blank=True,
         help_text=_('Provide a valid (escaped) JSON configuration. See '
-            'http://developers.google.com/maps/documentation/javascript/styling'),
+                    'http://developers.google.com/maps/documentation/javascript/styling'),
     )
     lat = models.FloatField(
         verbose_name=_('Latitude (lat)'),
@@ -160,6 +159,7 @@ class GoogleMap(CMSPlugin):
         CMSPlugin,
         related_name='%(app_label)s_%(class)s',
         parent_link=True,
+        on_delete=models.CASCADE,
     )
 
     def __str__(self):

--- a/setup.py
+++ b/setup.py
@@ -4,9 +4,8 @@ from setuptools import find_packages, setup
 
 from djangocms_googlemap import __version__
 
-
 REQUIREMENTS = [
-    'django-cms>=3.3.0',
+    'django-cms>=3.4.5',
     'django-filer'
 ]
 
@@ -24,6 +23,7 @@ CLASSIFIERS = [
     'Programming Language :: Python :: 3',
     'Programming Language :: Python :: 3.4',
     'Programming Language :: Python :: 3.5',
+    'Programming Language :: Python :: 3.6',
     'Topic :: Internet :: WWW/HTTP',
     'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
     'Topic :: Software Development :: Libraries :: Application Frameworks',
@@ -38,7 +38,7 @@ setup(
     author_email='info@divio.com',
     url='https://github.com/divio/djangocms-googlemap',
     license='BSD',
-    description=('Adds Google Maps plugins to django CMS.'),
+    description='Adds Google Maps plugins to django CMS.',
     long_description=open('README.rst').read(),
     packages=find_packages(),
     include_package_data=True,

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -3,3 +3,4 @@
 djangocms-helper>=0.9.2,<0.10
 tox
 coverage
+django-mptt>=0.9.1

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -16,9 +16,11 @@ HELPER_SETTINGS = {
     'LANGUAGE_CODE': 'en',
 }
 
+
 def run():
     from djangocms_helper import runner
     runner.cms('djangocms_googlemap')
+
 
 if __name__ == '__main__':
     run()

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,9 @@
 [tox]
 envlist =
     flake8
-    py{34,27}-latest
-    py{34,27}-dj18-cms{34,33}
-    py{34,27}-dj19-cms{34,33}
+    py{36,35,34,27}-dj111-cms{35,34}
+    py{36,35,34}-dj20-cms{40,35}
+    py{36,35}-dj21-cms{40,35}
 
 skip_missing_interpreters=True
 
@@ -11,11 +11,12 @@ skip_missing_interpreters=True
 [testenv]
 deps =
     -r{toxinidir}/tests/requirements.txt
-    dj18: Django>=1.8,<1.9
-    dj19: Django>=1.9,<1.10
-    latest: django-cms
-    cms33: django-cms>=3.3,<3.4
+    dj111: Django>=1.11,<2.0
+    dj20: Django>=2.0,<2.1
+    dj21: Django>=2.1,<2.2
     cms34: django-cms>=3.4,<3.5
+    cms35: django-cms>=3.5,<3.6
+    cms40: https://github.com/divio/django-cms/archive/release/4.0.x.zip
 commands =
     {envpython} --version
     {env:COMMAND:coverage} erase


### PR DESCRIPTION
Add support for new Django versions (based on #72 ):
- [X] 1.11
- [X] 2.0
- [X] 2.1

Drop support for old Django versions:
- [X] 1.8
- [X] 1.9
- [X] 1.10