### PR TITLE
Add rendering on plugin insert capability

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,6 @@ matrix:
       env: DJANGO='dj21' CMS='cms37'
     # Django 2.2
     - python: 3.6
-      dist: xenial
       env: DJANGO='dj22' CMS='cms37'
     - python: 3.7
       env: DJANGO='dj22' CMS='cms37'

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ matrix:
       env: DJANGO='dj21' CMS='cms37'
     # Django 2.2
     - python: 3.6
+      dist: xenial
       env: DJANGO='dj22' CMS='cms37'
     - python: 3.7
       env: DJANGO='dj22' CMS='cms37'

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog
 =========
 
+1.3.1 (unreleased)
+==================
+
+* Add rendering on plugin first insert capability
+
 
 1.3.0 (2019-05-23)
 ==================

--- a/djangocms_googlemap/static/djangocms_googlemap/js/djangocms.googlemap.js
+++ b/djangocms_googlemap/static/djangocms_googlemap/js/djangocms.googlemap.js
@@ -301,13 +301,28 @@
         return GoogleMapConstructor;
     })();
 
-    // make sure google maps is loaded after our dom is ready
-    window.addEventListener('load', function () {
+    function InitMap() {
         var elements = document.getElementsByClassName('js-djangocms-googlemap');
 
         elements = [].slice.call(elements);
         elements.forEach(function (element) {
-            new GoogleMap(element);
+            var container = element.querySelector('.djangocms-googlemap-container');
+            // make sure google map wasn't already initialized on that element
+            if (!container.hasChildNodes()) {
+                new GoogleMap(element);
+            }
         }, this);
+
+    }
+
+    // make sure google maps is loaded after our dom is ready
+    window.addEventListener('load', function () {
+        InitMap();
     });
+
+    if (window.CMS !== undefined) {
+        CMS.$(window).on('cms-content-refresh', function() {
+            InitMap();
+        })
+    }
 })();

--- a/djangocms_googlemap/templates/djangocms_googlemap/default/map.html
+++ b/djangocms_googlemap/templates/djangocms_googlemap/default/map.html
@@ -29,33 +29,47 @@ prevents a disaligne bug of the images in the controls,
 when the map is redrawn (trigger of the event 'cms-content-refresh'),
 taken from googles examples
 {% endcomment %}
-{% addtoblock "css" %}
-    <style type="text/css">
-        .gm-control-active>img {
-            box-sizing: content-box;
-            left: 50%;
-            pointer-events: none;
-            position: absolute;
-            top: 50%;
-            transform: translate(-50%,-50%);
-        }
-        .gm-control-active>img:first-child {
-            z-index: 100;
-        }
-    </style>
-{% endaddtoblock %}
+{% if request.toolbar and request.toolbar.edit_mode_active or request.toolbar and request.toolbar.edit_mode %}
+    {% addtoblock "css" %}
+        <style type="text/css">
+            .gm-control-active>img {
+                box-sizing: content-box;
+                left: 50%;
+                pointer-events: none;
+                position: absolute;
+                top: 50%;
+                transform: translate(-50%,-50%);
+            }
+            .gm-control-active>img:first-child {
+                z-index: 100;
+            }
+        </style>
+    {% endaddtoblock %}
+{% endif %}
 
+{% comment %}
+cms_js_classes are for injecting and executing javascript code properly,
+when the plugin is added to a page for the first time
+{% endcomment %}
+{% with cms_js_classes="cms-execute-js-to-render cms-trigger-event-window-load" %}
+    {% addtoblock "js" %}
+        <script src="https://maps.googleapis.com/maps/api/js{% if googlemap_key %}?key={{ googlemap_key }}{% endif %}"
+            {% if request.toolbar and request.toolbar.edit_mode_active or request.toolbar and request.toolbar.edit_mode %}
+                class="{{cms_js_classes}}"
+            {% endif %}
+        async defer>
+        </script>
+    {% endaddtoblock %}
 
-{% addtoblock "js" %}
-    <script src="https://maps.googleapis.com/maps/api/js{% if googlemap_key %}?key={{ googlemap_key }}{% endif %}"
-            class="cms-execute-js-to-render cms-trigger-event-window-load" async defer>
-    </script>
-{% endaddtoblock %}
-{% addtoblock "js" %}
-    <script src="{% static 'djangocms_googlemap/js/djangocms.googlemap.js' %}"
-            class="cms-execute-js-to-render cms-trigger-event-window-load" async defer>
-    </script>
-{% endaddtoblock %}
+    {% addtoblock "js" %}
+        <script src="{% static 'djangocms_googlemap/js/djangocms.googlemap.js' %}"
+            {% if request.toolbar and request.toolbar.edit_mode_active or request.toolbar and request.toolbar.edit_mode %}
+                class="{{cms_js_classes}}"
+            {% endif %}
+        async defer>
+        </script>
+    {% endaddtoblock %}
+{% endwith %}
 
 {% comment %}
     {{ googlemap_key }}

--- a/djangocms_googlemap/templates/djangocms_googlemap/default/map.html
+++ b/djangocms_googlemap/templates/djangocms_googlemap/default/map.html
@@ -25,7 +25,9 @@
     {% endfor %}
 </div>
 {% comment %}
-prevents a disaligne bug, when the map is redrawn, take from googles examples
+prevents a disaligne bug of the images in the controls,
+when the map is redrawn (trigger of the event 'cms-content-refresh'),
+taken from googles examples
 {% endcomment %}
 {% addtoblock "css" %}
     <style type="text/css">

--- a/djangocms_googlemap/templates/djangocms_googlemap/default/map.html
+++ b/djangocms_googlemap/templates/djangocms_googlemap/default/map.html
@@ -24,9 +24,36 @@
         {% render_plugin plugin %}
     {% endfor %}
 </div>
+{% comment %}
+prevents a disaligne bug, when the map is redrawn, take from googles examples
+{% endcomment %}
+{% addtoblock "css" %}
+    <style type="text/css">
+        .gm-control-active>img {
+            box-sizing: content-box;
+            left: 50%;
+            pointer-events: none;
+            position: absolute;
+            top: 50%;
+            transform: translate(-50%,-50%);
+        }
+        .gm-control-active>img:first-child {
+            z-index: 100;
+        }
+    </style>
+{% endaddtoblock %}
 
-{% addtoblock "js" %}<script src="https://maps.googleapis.com/maps/api/js{% if googlemap_key %}?key={{ googlemap_key }}{% endif %}" async defer></script>{% endaddtoblock %}
-{% addtoblock "js" %}<script src="{% static 'djangocms_googlemap/js/djangocms.googlemap.js' %}" async defer></script>{% endaddtoblock %}
+
+{% addtoblock "js" %}
+    <script src="https://maps.googleapis.com/maps/api/js{% if googlemap_key %}?key={{ googlemap_key }}{% endif %}"
+            class="cms-execute-js-to-render cms-trigger-event-window-load" async defer>
+    </script>
+{% endaddtoblock %}
+{% addtoblock "js" %}
+    <script src="{% static 'djangocms_googlemap/js/djangocms.googlemap.js' %}"
+            class="cms-execute-js-to-render cms-trigger-event-window-load" async defer>
+    </script>
+{% endaddtoblock %}
 
 {% comment %}
     {{ googlemap_key }}

--- a/djangocms_googlemap/templates/djangocms_googlemap/default/map.html
+++ b/djangocms_googlemap/templates/djangocms_googlemap/default/map.html
@@ -53,21 +53,25 @@ when the plugin is added to a page for the first time
 {% endcomment %}
 {% with cms_js_classes="cms-execute-js-to-render cms-trigger-event-window-load" %}
     {% addtoblock "js" %}
-        <script src="https://maps.googleapis.com/maps/api/js{% if googlemap_key %}?key={{ googlemap_key }}{% endif %}"
-            {% if request.toolbar and request.toolbar.edit_mode_active or request.toolbar and request.toolbar.edit_mode %}
-                class="{{cms_js_classes}}"
-            {% endif %}
-        async defer>
-        </script>
+        {% spaceless %}
+            <script src="https://maps.googleapis.com/maps/api/js{% if googlemap_key %}?key={{ googlemap_key }}{% endif %}"
+                {% if request.toolbar and request.toolbar.edit_mode_active or request.toolbar and request.toolbar.edit_mode %}
+                    class="{{cms_js_classes}}"
+                {% endif %}
+            async defer>
+            </script>
+        {% endspaceless %}
     {% endaddtoblock %}
 
     {% addtoblock "js" %}
-        <script src="{% static 'djangocms_googlemap/js/djangocms.googlemap.js' %}"
-            {% if request.toolbar and request.toolbar.edit_mode_active or request.toolbar and request.toolbar.edit_mode %}
-                class="{{cms_js_classes}}"
-            {% endif %}
-        async defer>
-        </script>
+        {% spaceless %}
+            <script src="{% static 'djangocms_googlemap/js/djangocms.googlemap.js' %}"
+                {% if request.toolbar and request.toolbar.edit_mode_active or request.toolbar and request.toolbar.edit_mode %}
+                    class="{{cms_js_classes}}"
+                {% endif %}
+            async defer>
+            </script>
+        {% endspaceless %}
     {% endaddtoblock %}
 {% endwith %}
 


### PR DESCRIPTION
I have a [PR on django-cms](https://github.com/divio/django-cms/pull/6699), which allows the dynamic execution of javascript for plugins when they are added the first time in edit mode.
Right now you need to publish the page or refresh it, to see the rendered map.
But when my [PR on django-cms](https://github.com/divio/django-cms/pull/6699) is merged, the map gets rendered right after adding the plugin for the first time.  